### PR TITLE
Initial gerrit plugin structure with SSH command

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,14 @@
+[alias]
+  selfserv = //:selfserv
+  plugin = //:selfserv
+
+[java]
+  src_roots = java, resources
+
+[project]
+  ignore = .git
+
+[cache]
+  mode = dir
+  dir = buck-out/cache
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/.buckversion
+/.buckd
+/buck-out
+/bucklets
+/target
+/.classpath
+/.project
+/.settings/org.maven.ide.eclipse.prefs
+/.settings/org.eclipse.m2e.core.prefs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,22 @@
+include_defs('//bucklets/gerrit_plugin.bucklet')
+
+gerrit_plugin(
+  name = 'selfserv',
+  srcs = glob(['src/main/java/**/*.java']),
+  resources = glob(['src/main/resources/**/*']),
+  manifest_entries = [
+    'Gerrit-PluginName: selfserv',
+    'Gerrit-ApiType: plugin',
+    'Gerrit-ApiVersion: 2.11',
+    'Gerrit-Module: com.lookout.gerrit.selfserv.Module',
+    'Gerrit-SshModule: com.lookout.gerrit.selfserv.SshModule',
+    'Gerrit-HttpModule: com.lookout.gerrit.selfserv.HttpModule',
+  ],
+)
+
+# this is required for bucklets/tools/eclipse/project.py to work
+java_library(
+  name = 'classpath',
+  deps = [':selfserv__plugin'],
+)
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2015, Susan Potter
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+  Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+  Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+  Neither the name of Susan Potter nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,234 @@
+## Selfserv Gerrit Plugin
+
+This is a Gerrit plugin that will provide self-service project creation
+for those in the `selfserv Admin` group.
+
+There are currently three commands that will be part of this plugin:
+
+* [create-project](src/main/resources/Documentation/cmd-create-project.md)
+* [add-user](src/main/resources/Documentation/cmd-add-user.md)
+* (TODO) [import-project](src/main/resources/Documentation/cmd-import-project.md)
+
+### The Problem Space
+
+We want to use Gerrit to streamline and restrict the Git workflow and review
+process for development efforts, but we also want simple, automated way to
+provide self-service capabilities for creating new projects without adding
+all users to the Administrators group and provide some structure around
+how Gerrit projects are created and setup.
+
+There are different ways we can do this:
+
+* Put a limited set of users (e.g. engineering managers, and/or techical
+  leads) in the Administrators group who we just want to create Gerrit
+  projects. Not ideal because all of these users will have full Gerrit
+  administrator permissions, which is not appropriate most of the time.
+  There is also ample opportunity to not create projects in a consistent
+  fashion (project permissions, submit strategy, change-id requirement, etc.)
+* Create a new group of users for these project administrator users and grant
+  'Create Project' global capability (a feature in Gerrit itsef) to this group,
+  then place desired users in this group and "ship" (read: distribute) client-
+  side scripts to these users so they can create projects in specific ways.
+  This isn't desireable either if we really do care about consistency and ease
+  of use for these users. Not al engineering managers are still comfortable
+  with using the Terminal any more and because they aren't actively developing
+  their dev environment for these scripts (e.g. bundler/gems/Ruby version,
+  virtualenv/pip/Python version, etc.) they may go stale and stop working and
+  require more support than necessary.
+* Create automation that is hosted inside Gerrit and uses Gerrit supported
+  plugin and/or extension APIs to provide the consistency of the second option.
+  The one-time setup of the new group and adding the necessary users to that
+  group and adding the 'Create Project' capability is still required. The
+  disadvantage of this approach is that the API is in Java and we don't have
+  a lot of direct Java skills at Lookout generally, especially (based on
+  comments from RelEng) inside RelEng. However, installing a Gerrit plugin
+  and operating the plugin is far more practical and secure than spinning up
+  a new service external to Gerrit where credentials need to be transported
+  and stored safely, etc.
+* Create automation to do the above that is hosted externally from Gerrit
+  itself. This gives us the opportunity to write the automation in whatever
+  language we care to support, but has the disadvantages that:
+
+  * we are creating a new set of components and/or service that needs to
+    be maintained and operated outside of Gerrit ecosystem itself.
+  * we have to securely transport and store credentials necessary to
+    run this automation outside of Gerrit itself.
+  * we have to the additional overhead of not just unit and functional
+    testing (as we would need to do with option #3 of building a Gerrit
+    plugin based on open source Gerrit APIs) but also end-to-end service
+    testing for the new external service for our automation.
+
+This project is opting to provide an initial implementation for option #3 of
+cohosting the Gerrit automation for this problem space inside the Gerrit
+runtime itself, giving us numerous benefits assuming we can navigate the
+Java Gerrit API which is open source and available.
+
+
+### Bootstrap
+
+Run the `bootstrap` script at the root directory of the plugin Git repository.
+
+```shell
+$ ./bootstrap
+Setting up local Gerrit site dev env in /tmp/gerrit-site
+~/src/oss/gerrit-selfserv ~/src/oss/gerrit-selfserv
+[INFO] Scanning for projects...
+[INFO]
+[INFO] ------------------------------------------------------------------------
+[INFO] Building selfserv 0.1.0-SNAPSHOT
+[INFO] ------------------------------------------------------------------------
+[INFO]
+[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ selfserv ---
+[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
+[INFO] Copying 5 resources
+[INFO]
+[INFO] --- maven-compiler-plugin:2.3.2:compile (default-compile) @ selfserv ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO]
+[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ selfserv ---
+[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
+[INFO] skip non existing resourceDirectory /home/spotter/src/oss/gerrit-selfserv/src/test/resources
+[INFO]
+[INFO] --- maven-compiler-plugin:2.3.2:testCompile (default-testCompile) @ selfserv ---
+[INFO] Nothing to compile - all classes are up to date
+[INFO]
+[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ selfserv ---
+[INFO] Surefire report directory: /home/spotter/src/oss/gerrit-selfserv/target/surefire-reports
+
+-------------------------------------------------------
+T E S T S
+-------------------------------------------------------
+Running com.lookout.gerrit.selfserv.ssh.CreateProjectCommandTest
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.877 sec
+
+Results :
+
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
+
+[INFO]
+[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ selfserv ---
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 2.651 s
+[INFO] Finished at: 2015-05-11T07:39:02-05:00
+[INFO] Final Memory: 13M/303M
+[INFO] ------------------------------------------------------------------------
+~/src/oss/gerrit-selfserv
+/tmp/gerrit-site ~/src/oss/gerrit-selfserv
+Starting Gerrit Code Review: Already Running!!
+~/src/oss/gerrit-selfserv
+Using /home/spotter/.ssh/gerrit2.id_rsa for dev env
+
+~~~~~~~~~~~~
+INSTRUCTIONS
+~~~~~~~~~~~~
+Add an entry to your /home/spotter/.ssh/config file for your development gerrit
+Maybe something like this:
+
+Host gerrit.dev
+  Hostname localhost
+  Port 29418
+  User spotter
+  IdentityFile /home/spotter/.ssh/gerrit2.id_rsa
+
+Now:
+1. register a new user account spotter at: http://localhost:8080/#/register
+2. Upload your SSH public key at /home/spotter/.ssh/gerrit2.id_rsa.pub
+3. Run: ssh -p 29418 localhost -- gerrit plugin ls
+```
+
+Once you have followed the insutructions below to setup a local Gerrit server
+development environment so you can do test out the Gerrit plugin functionality,
+you should be able to observe the following in the Gerrit SSH commands:
+
+```shell
+$ ssh gerrit.dev -- gerrit plugin ls
+Name                           Version    Status   File
+-------------------------------------------------------------------------------
+selfserv                       0.1.0-SNAPSHOT ENABLED  selfserv-0.1.0-SNAPSHOT.jar
+
+$ ssh gerrit.dev -- selfserv
+Available commands of selfserv are:
+
+   add-user
+   create-project
+   import-project
+
+See 'selfserv COMMAND --help' for more information.
+
+$ ssh gerrit.dev -- selfserv create-project
+fatal: Argument "NAME" is required
+
+$ ssh gerrit.dev -- selfserv create-project --help
+selfserv create-project NAME [--] [--change-id [TRUE | FALSE | INHERIT]] [--description DESC] [--empty-commit] [--help (-h)] [--parent PARENT]
+
+  --                                   : end of options
+  --change-id [TRUE | FALSE | INHERIT] : Require Change-Id in commits
+  --description DESC                   : Description of the project to create
+  --empty-commit                       : Creates initial empty commit
+  --help (-h)                          : display this help text
+  --parent PARENT                      : Name of parent repository
+
+$ ssh gerrit.dev -- selfserv create-project myawesomeserver
+Expected admin group (selfserv+Admins) does not exist.
+```
+
+Now we haven't created the admin group needed for the Gerrit plugin, so the
+plugin nicely warns us abotu this via an errorneous SSH command (exit code 1
+and useful error message written to stderr). So we can fix this in a few ways,
+my favorite being the builtin Gerrit SSH command `gerrit create-groups GROUPNAME`:
+
+```
+$ ssh gerrit.dev -- gerrit create-group \"selfserv Admins\"
+```
+
+Now we can proceed using the `selfserv` Gerrit plugin like so:
+
+```
+$ ssh gerrit.dev -- selfserv add-user $USER
+Added $USER to adminGroup
+
+$ ssh gerrit.dev -- selfserv create-project myawesomeserver
+Created project: myawesomeserver
+
+$ ssh gerrit.dev -- selfserv create-project myawesomeserver
+Project myawesomeserver already exists.
+```
+
+Note when there is an error the SSH command on the client side returns with a
+non-zero exit with appropriate error message. So this can be used for
+automation given that basic contract. Otherwise successful messaging will be
+printed to stdout.
+
+The last SSH command above returns with an exitcode of 1 and prints the error
+message to stderr as expected for a UNIX tool.
+
+
+### Deployment
+
+To configure this plugin read the
+[attached config documentation](src/main/resources/Documentation/config.md)
+
+Gerrit provides a mechanism to live deploy plugins by copying the final JAR
+Gerrit plugin artifact into the `${GERRIT_SITE}/plugins` directory.
+
+### Status
+
+CI: [![Build Status](https://travis-ci.org/mbbx6spp/gerrit-selfserv.svg)](https://travis-ci.org/mbbx6spp/gerrit-selfserv)
+
+The CI build will do the following:
+
+```
+mvn verify
+```
+
+This goal will:
+
+* compile the Java sources
+* run the test suite
+* run `findBugs` on the main source code (code under `src/main/java`) to find
+  sources of common bug patterns in Java. I set this in the POM with a low
+  threshold to catch more problems earlier.
+
+

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,5 @@
+# Used by BUCK to include "Implementation-Version" in plugin Manifest.
+# If this file doesn't exist the output of 'git describe' is used
+# instead.
+PLUGIN_VERSION = '0.1.0-SNAPSHOT'
+

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  >&2 echo "Error: Sourced an executable file ${BASH_SOURCE[0]}."
+else
+  declare -r work_dir="${1:-/tmp}"
+  declare -r plugin_dir="${PWD}"
+  declare -r gerrit_version="2.11"
+  declare -r plugin_name="${2:-selfserv}"
+  declare -r plugin_version="0.1.0"
+  declare -r gerrit_repo_url="https://gerrit.googlesource.com/gerrit"
+  declare -r gerrit_site="${work_dir}/gerrit-site"
+  declare -r gerrit_war_url="gerrit-releases.storage.googleapis.com/gerrit-${gerrit_version}.war"
+  declare -r gerrit_war_file="${gerrit_site}/gerrit-${gerrit_version}.war"
+  declare -i gerrit_ssh_port=29418
+  declare -r gerrit_ssh_key="${HOME}/.ssh/gerrit2.id_rsa"
+  declare -r gerrit_pub_key="${HOME}/.ssh/gerrit2.id_rsa.pub"
+
+  mkdir -p "${work_dir}"
+
+  echo "Setting up local Gerrit site dev env in ${gerrit_site}"
+  if [ ! -f "${gerrit_war_file}" ]; then
+    mkdir -p "${gerrit_site}"
+    pushd "${gerrit_site}"
+    echo "Downloading v${gerrit_version} gerrit.war..."
+    wget -q "${gerrit_war_url}" -O "${gerrit_war_file}"
+    java -jar "${gerrit_war_file}" init --batch -d "${gerrit_site}"
+    java -jar "${gerrit_war_file}" reindex -d "${gerrit_site}"
+    git config -f "etc/gerrit.config" --null gerrit.canonicalWebUrl
+    git config -f "etc/gerrit.config" gerrit.canonicalWebUrl http://localhost:8080/
+    git config -f "etc/gerrit.config" --null auth.type
+    # Only for development purposes, don't ever do this on a real Gerrit server
+    git config -f "etc/gerrit.config" auth.type DEVELOPMENT_BECOME_ANY_ACCOUNT
+    popd
+  fi
+
+  set -eu
+  if [ ! -d "${work_dir}/gerrit" ]; then
+    git clone --branch "v${gerrit_version}" \
+      "${gerrit_repo_url}" \
+      "${work_dir}/gerrit"
+  fi
+
+  pushd "${plugin_dir}"
+  mvn package
+  cp "target/${plugin_name}-${plugin_version}-SNAPSHOT.jar" "${gerrit_site}/plugins"
+  popd
+
+  pushd "${gerrit_site}"
+  ./bin/gerrit.sh start
+  popd
+
+  if [ ! -f "${gerrit_ssh_key}" ]; then
+    echo -n "No ${gerrit_ssh_key} so generating one for dev env..."
+    ssh-keygen -q -b 2048 -t rsa \
+      -C "Key pair for local gerrit plugin development" \
+      -f "${gerrit_ssh_key}"
+    echo "DONE."
+  else
+    echo "Using ${gerrit_ssh_key} for dev env"
+  fi
+
+  echo
+  echo "~~~~~~~~~~~~"
+  echo "INSTRUCTIONS"
+  echo "~~~~~~~~~~~~"
+  echo "Add an entry to your ${HOME}/.ssh/config file for your development gerrit"
+  echo "Maybe something like this:"
+  echo
+  echo "Host gerrit.dev"
+  echo "  Hostname localhost"
+  echo "  Port 29418"
+  echo "  User ${USER}"
+  echo "  IdentityFile ${gerrit_ssh_key}"
+  echo
+  echo "Now:"
+  echo "1. register a new user account ${USER} at: http://localhost:8080/#/register"
+  echo "2. Upload your SSH public key at ${gerrit_pub_key}"
+  echo "3. Run: ssh -p ${gerrit_ssh_port} localhost -- gerrit plugin ls"
+fi

--- a/lib/gerrit/BUCK
+++ b/lib/gerrit/BUCK
@@ -1,0 +1,12 @@
+include_defs('//bucklets/maven_jar.bucklet')
+
+VER = '2.11'
+REPO = MAVEN_LOCAL
+
+maven_jar(
+  name = 'plugin-api',
+  id = 'com.google.gerrit:gerrit-plugin-api:' + VER,
+  attach_source = False,
+  repository = REPO,
+  license = 'Apache2.0',
+)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,122 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.lookout.gerrit.selfserv</groupId>
+  <artifactId>selfserv</artifactId>
+  <packaging>jar</packaging>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>selfserv</name>
+
+  <properties>
+    <Gerrit-ApiType>plugin</Gerrit-ApiType>
+    <Gerrit-ApiVersion>2.11</Gerrit-ApiVersion>
+    <powermock.version>1.6.2</powermock.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Gerrit-PluginName>selfserv</Gerrit-PluginName>
+              <Gerrit-Module>com.lookout.gerrit.selfserv.Module</Gerrit-Module>
+              <Gerrit-SshModule>com.lookout.gerrit.selfserv.SshModule</Gerrit-SshModule>
+              <Gerrit-HttpModule>com.lookout.gerrit.selfserv.HttpModule</Gerrit-HttpModule>
+              <!--
+              <Gerrit-InitStep>com.lookout.gerrit.selfserv.InitStep</Gerrit-InitStep>
+              -->
+
+              <Implementation-Vendor>Lookout</Implementation-Vendor>
+              <Implementation-URL>http://github.com/lookout</Implementation-URL>
+
+              <Implementation-Title>${Gerrit-ApiType} ${project.artifactId}</Implementation-Title>
+              <Implementation-Version>${project.version}</Implementation-Version>
+
+              <Gerrit-ApiType>${Gerrit-ApiType}</Gerrit-ApiType>
+              <Gerrit-ApiVersion>${Gerrit-ApiVersion}</Gerrit-ApiVersion>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <effort>Max</effort>
+          <threshold>Low</threshold>
+          <xmlOutput>true</xmlOutput>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.gerrit</groupId>
+      <artifactId>gerrit-${Gerrit-ApiType}-api</artifactId>
+      <version>${Gerrit-ApiVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>findbugs-maven-plugin</artifactId>
+      <version>3.0.1</version>
+      <type>maven-plugin</type>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.0.7-beta</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/main/java/com/lookout/gerrit/selfserv/Defaults.java
+++ b/src/main/java/com/lookout/gerrit/selfserv/Defaults.java
@@ -1,0 +1,25 @@
+package com.lookout.gerrit.selfserv;
+
+import com.google.gerrit.reviewdb.client.AccountGroup;
+
+import com.google.gerrit.server.config.PluginConfigFactory;
+
+public class Defaults {
+  public static final String getPluginName() {
+    return "selfserv";
+  }
+
+  public static final String getDefaultAdminGroup() {
+    return getPluginName() + " Admins";
+  }
+
+  public static final String getAdminGroupKey() {
+    return "adminGroup";
+  }
+
+  public static AccountGroup.NameKey getAdminGroupNameKey(PluginConfigFactory cfg) {
+    String groupName = cfg.getFromGerritConfig(getPluginName()).
+      getString(getAdminGroupKey(), getDefaultAdminGroup());
+    return new AccountGroup.NameKey(groupName);
+  }
+}

--- a/src/main/java/com/lookout/gerrit/selfserv/HttpModule.java
+++ b/src/main/java/com/lookout/gerrit/selfserv/HttpModule.java
@@ -1,0 +1,10 @@
+package com.lookout.gerrit.selfserv;
+
+import com.google.inject.servlet.ServletModule;
+
+class HttpModule extends ServletModule {
+  @Override
+  protected void configureServlets() {
+    // TODO
+  }
+}

--- a/src/main/java/com/lookout/gerrit/selfserv/Module.java
+++ b/src/main/java/com/lookout/gerrit/selfserv/Module.java
@@ -1,0 +1,28 @@
+package com.lookout.gerrit.selfserv;
+
+import com.google.inject.Inject;
+import com.google.inject.AbstractModule;
+
+import com.google.gerrit.server.config.PluginConfig;
+import com.google.gerrit.server.config.PluginConfigFactory;
+
+import static com.lookout.gerrit.selfserv.Defaults.*;
+
+public class Module extends AbstractModule {
+  @Inject
+  private PluginConfigFactory _pluginCfg;
+
+  @Override
+  protected void configure() {
+    final PluginConfig cfg = _pluginCfg.
+      getFromGerritConfig(getPluginName());
+
+    final String adminGrp = cfg.getString(getAdminGroupKey());
+
+    if (adminGrp == null) {
+      cfg.setString(
+        getAdminGroupKey(),
+        getDefaultAdminGroup());
+    }
+  }
+}

--- a/src/main/java/com/lookout/gerrit/selfserv/SshModule.java
+++ b/src/main/java/com/lookout/gerrit/selfserv/SshModule.java
@@ -1,0 +1,16 @@
+package com.lookout.gerrit.selfserv;
+
+import com.google.gerrit.sshd.PluginCommandModule;
+
+import com.lookout.gerrit.selfserv.ssh.AddUserCommand;
+import com.lookout.gerrit.selfserv.ssh.CreateProjectCommand;
+import com.lookout.gerrit.selfserv.ssh.ImportProjectCommand;
+
+class SshModule extends PluginCommandModule {
+  @Override
+  protected void configureCommands() {
+    command("add-user").to(AddUserCommand.class);
+    command("create-project").to(CreateProjectCommand.class);
+    command("import-project").to(ImportProjectCommand.class);
+  }
+}

--- a/src/main/java/com/lookout/gerrit/selfserv/ssh/AddUserCommand.java
+++ b/src/main/java/com/lookout/gerrit/selfserv/ssh/AddUserCommand.java
@@ -1,0 +1,110 @@
+package com.lookout.gerrit.selfserv.ssh;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.common.collect.Lists;
+import com.google.gerrit.common.data.GlobalCapability;
+import com.google.gerrit.extensions.annotations.Export;
+import com.google.gerrit.extensions.annotations.RequiresCapability;
+import com.google.gerrit.extensions.api.GerritApi;
+import com.google.gerrit.extensions.restapi.IdString;
+import com.google.gerrit.extensions.restapi.TopLevelResource;
+import com.google.gerrit.extensions.restapi.UnprocessableEntityException;
+
+import com.google.gerrit.reviewdb.client.AccountGroup;
+
+import com.google.gerrit.server.account.GroupCache;
+import com.google.gerrit.server.group.AddMembers;
+import com.google.gerrit.server.group.GroupsCollection;
+import com.google.gerrit.server.group.GroupResource;
+
+import com.google.gerrit.server.config.PluginConfigFactory;
+
+import com.google.gerrit.sshd.SshCommand;
+import com.google.gerrit.sshd.CommandMetaData;
+
+import org.kohsuke.args4j.Argument;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.io.PrintWriter;
+
+import static com.lookout.gerrit.selfserv.Defaults.*;
+
+/**
+  * Adds a user to the +adminGroup+ for the selfserv plugin.
+  */
+@Export("add-user")
+@RequiresCapability(GlobalCapability.ADMINISTRATE_SERVER)
+@CommandMetaData( name = "add-user",
+                  description = "Add user to the selfserv.adminGroup and grant appropriate capabilities")
+public class AddUserCommand extends SshCommand {
+  private final Provider<AddMembers> _addMembers;
+  private final GroupsCollection _groupsCollection;
+  private final GroupCache _groupCache;
+  private final PluginConfigFactory _pluginCfg;
+
+  @Argument(index = 0,
+            metaVar = "USERNAME",
+            required = true)
+  private String _username;
+
+  @Inject
+  public AddUserCommand(
+    final Provider<AddMembers> addMembers,
+    final GroupsCollection groupsCollection,
+    final GroupCache groupCache,
+    final PluginConfigFactory pluginCfg) {
+
+    this._addMembers = addMembers;
+    this._groupsCollection = groupsCollection;
+    this._groupCache = groupCache;
+    this._pluginCfg = pluginCfg;
+  }
+
+  /**
+    * Used for testing purposes to inject (manually) mocks.
+    */
+  public AddUserCommand(
+    final Provider<AddMembers> addMembers,
+    final GroupsCollection groupsCollection,
+    final GroupCache groupCache,
+    final PluginConfigFactory pluginCfg,
+    final PrintWriter printWriter) {
+
+    this(addMembers, groupsCollection, groupCache, pluginCfg);
+
+    if (printWriter != null) {
+      this.stdout = printWriter;
+    }
+  }
+
+  @Override
+  public void run() throws UnloggedFailure, Failure, Exception {
+    if (_username == null) {
+      stdout.println(usage());
+    } else {
+      final AccountGroup.NameKey nameKey = getAdminGroupNameKey(_pluginCfg);
+      final AccountGroup ag = _groupCache.get(nameKey);
+
+      if (ag == null) {
+        // TODO: Decide if I should throw an UnloggedFailure here instead of Failure?
+        throw new Failure(1, "Expected admin group (" + nameKey.toString() + ") does not exist.");
+      }
+
+      final GroupResource resource = _groupsCollection.parse(
+        TopLevelResource.INSTANCE,
+        IdString.fromUrl(ag.getGroupUUID().get()));
+      final List<String> members = Lists.newLinkedList();
+      members.add(_username);
+      final AddMembers.Input input = AddMembers.Input.fromMembers(members);
+      try {
+        _addMembers.get().apply(resource, input);
+        stdout.println("Added " + _username + " to adminGroup");
+      } catch (UnprocessableEntityException uee) { /* FYI this is gross, but the API is a clusterfuck, sorry! */
+        throw new Failure(1, "Username (" + _username + ") couldn't be added to adminGroup", uee);
+      }
+    }
+  }
+}

--- a/src/main/java/com/lookout/gerrit/selfserv/ssh/CreateProjectCommand.java
+++ b/src/main/java/com/lookout/gerrit/selfserv/ssh/CreateProjectCommand.java
@@ -1,0 +1,145 @@
+package com.lookout.gerrit.selfserv.ssh;
+
+import com.google.inject.Inject;
+import com.google.gerrit.common.data.GlobalCapability;
+import com.google.gerrit.extensions.annotations.Export;
+import com.google.gerrit.extensions.annotations.RequiresCapability;
+import com.google.gerrit.extensions.api.GerritApi;
+import com.google.gerrit.extensions.api.projects.ProjectApi;
+import com.google.gerrit.extensions.api.projects.ProjectInput;
+import com.google.gerrit.extensions.client.InheritableBoolean;
+import com.google.gerrit.extensions.client.SubmitType;
+import com.google.gerrit.extensions.common.ProjectInfo;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gerrit.extensions.restapi.ResourceConflictException;
+
+import com.google.gerrit.reviewdb.client.AccountGroup;
+
+import com.google.gerrit.server.CurrentUser;
+import com.google.gerrit.server.account.GroupMembership;
+import com.google.gerrit.server.account.GroupCache;
+import com.google.gerrit.server.account.GroupControl;
+import com.google.gerrit.server.config.PluginConfigFactory;
+import com.google.gerrit.server.git.strategy.FastForwardOnly;
+
+import com.google.gerrit.sshd.SshCommand;
+import com.google.gerrit.sshd.CommandMetaData;
+
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.io.PrintWriter;
+
+import static com.lookout.gerrit.selfserv.Defaults.*;
+
+/**
+  * Creates project in selfserv plugin using optinionated scheme:
+  * * Set submit strategy to fast-forward only
+  */
+@Export("create-project")
+@RequiresCapability(GlobalCapability.CREATE_PROJECT)
+@CommandMetaData( name = "create-project",
+                  description = "Create a new project and associated Git repository")
+public class CreateProjectCommand extends SshCommand {
+  private final GerritApi _gerritApi;
+  private final CurrentUser _currentUser;
+  private final GroupCache _groupCache;
+  private final PluginConfigFactory _pluginCfg;
+
+  @Argument(index = 0,
+            metaVar = "NAME",
+            required = true)
+  private String _name;
+
+  @Option(name = "--description",
+          usage = "Description of the project to create",
+          metaVar = "DESC")
+  private String _description;
+
+  @Option(name = "--parent",
+          usage = "Name of parent repository",
+          metaVar = "PARENT")
+  private String _parent;
+
+  @Option(name = "--empty-commit",
+          usage = "Creates initial empty commit")
+  private boolean _emptyCommit = false;
+
+  @Option(name = "--change-id",
+          usage = "Require Change-Id in commits")
+  private InheritableBoolean _requireChangeId = InheritableBoolean.TRUE;
+
+  @Inject
+  public CreateProjectCommand(
+    final GerritApi gerritApi,
+    final PluginConfigFactory pluginCfg,
+    final CurrentUser currentUser,
+    final GroupCache groupCache) {
+
+    this._gerritApi = gerritApi;
+    this._pluginCfg = pluginCfg;
+    this._currentUser = currentUser;
+    this._groupCache = groupCache;
+  }
+
+  /**
+    * Used for testing purposes to inject (manually) mocks.
+    */
+  public CreateProjectCommand(
+    final GerritApi gerritApi,
+    final PluginConfigFactory pluginCfg,
+    final CurrentUser currentUser,
+    final GroupCache groupCache,
+    final PrintWriter printWriter) {
+
+    this(gerritApi, pluginCfg, currentUser, groupCache);
+
+    if (printWriter != null) {
+      this.stdout = printWriter;
+    }
+  }
+
+  @Override
+  public void run() throws UnloggedFailure, Failure, Exception {
+    if (_name == null) {
+      stdout.println(usage());
+    } else {
+      // TODO: Extract out into "action" class a la Strategy/Command design
+      // pattern since we are targetting Java 7 for the moment which doesn't
+      // permit natural higher order functions.
+      final GroupMembership groups = getGroups();
+      final AccountGroup.NameKey nameKey = getAdminGroupNameKey(_pluginCfg);
+      final AccountGroup ag = _groupCache.get(nameKey);
+
+      if (ag == null) {
+        // TODO: Decide if I should throw an UnloggedFailure here instead of Failure?
+        throw new Failure(1, "Expected admin group (" + nameKey.toString() + ") does not exist.");
+      }
+
+      if (groups != null && groups.contains(ag.getGroupUUID())) {
+        final ProjectInput input = new ProjectInput();
+        input.name = _name;
+        input.description = _description;
+        input.submitType = SubmitType.FAST_FORWARD_ONLY;
+        input.createEmptyCommit = _emptyCommit;
+        input.requireChangeId = _requireChangeId;
+
+        ProjectApi projectApi = _gerritApi.projects().name(_name);
+        try {
+          projectApi.create(input);
+          stdout.println("Created project: " + _name);
+        } catch (ResourceConflictException rce) {
+          throw new Failure(1, "Project " + _name + " already exists.", rce);
+        }
+      }
+    }
+  }
+
+  private GroupMembership getGroups() {
+    return _currentUser.getEffectiveGroups();
+  }
+
+}

--- a/src/main/java/com/lookout/gerrit/selfserv/ssh/ImportProjectCommand.java
+++ b/src/main/java/com/lookout/gerrit/selfserv/ssh/ImportProjectCommand.java
@@ -1,0 +1,71 @@
+package com.lookout.gerrit.selfserv.ssh;
+
+import com.google.inject.Inject;
+import com.google.gerrit.common.data.GlobalCapability;
+import com.google.gerrit.extensions.annotations.Export;
+import com.google.gerrit.extensions.annotations.RequiresCapability;
+import com.google.gerrit.extensions.api.GerritApi;
+
+import com.google.gerrit.server.config.PluginConfigFactory;
+
+import com.google.gerrit.sshd.SshCommand;
+import com.google.gerrit.sshd.CommandMetaData;
+
+import org.kohsuke.args4j.Argument;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.io.PrintWriter;
+
+import static com.lookout.gerrit.selfserv.Defaults.*;
+
+/**
+  * Adds a user to the +adminGroup+ for the selfserv plugin.
+  */
+@Export("import-project")
+@RequiresCapability(GlobalCapability.ADMINISTRATE_SERVER)
+@CommandMetaData( name = "import-project",
+                  description = "Imports projects from existing Git remote")
+public class ImportProjectCommand extends SshCommand {
+  private final GerritApi _gerritApi;
+  private final PluginConfigFactory _pluginCfg;
+
+  @Argument(index = 0,
+            metaVar = "NAME",
+            required = true)
+  private String _name;
+
+  @Inject
+  public ImportProjectCommand(
+    final GerritApi gerritApi,
+    final PluginConfigFactory pluginCfg) {
+
+    this._gerritApi = gerritApi;
+    this._pluginCfg = pluginCfg;
+  }
+
+  /**
+    * Used for testing purposes to inject (manually) mocks.
+    */
+  public ImportProjectCommand(
+    final GerritApi gerritApi,
+    final PluginConfigFactory pluginCfg,
+    final PrintWriter printWriter) {
+
+    this(gerritApi, pluginCfg);
+
+    if (printWriter != null) {
+      this.stdout = printWriter;
+    }
+  }
+
+  @Override
+  public void run() throws UnloggedFailure, Failure, Exception {
+    if (_name == null) {
+      stdout.println(usage());
+    } else {
+      throw new Failure(1, "Not implemented.");
+    }
+  }
+}

--- a/src/main/resources/Documentation/build.md
+++ b/src/main/resources/Documentation/build.md
@@ -1,0 +1,77 @@
+Build
+=====
+
+This plugin can be built with Buck or Maven.
+
+Buck
+----
+
+Two build modes are supported: Standalone and in Gerrit tree.
+The standalone build mode is recommended, as this mode doesn't require
+the Gerrit tree to exist locally.
+
+
+
+Clone bucklets library:
+
+```
+  git clone https://gerrit.googlesource.com/bucklets
+
+```
+and link it to @PLUGIN@ plugin directory:
+
+```
+  cd @PLUGIN@ && ln -s ../bucklets .
+```
+
+Add link to the .buckversion file:
+
+```
+  cd @PLUGIN@ && ln -s bucklets/buckversion .buckversion
+```
+
+To build the plugin, issue the following command:
+
+
+```
+  buck build plugin
+```
+
+The output is created in
+
+```
+  buck-out/gen/@PLUGIN@.jar
+```
+
+
+Clone or link this plugin to the plugins directory of Gerrit's source
+tree, and issue the command:
+
+```
+  buck build plugins/@PLUGIN@
+```
+
+The output is created in
+
+```
+  buck-out/gen/plugins/@PLUGIN@/@PLUGIN@.jar
+```
+
+This project can be imported into the Eclipse IDE:
+
+```
+  ./tools/eclipse/project.py
+```
+
+Maven
+-----
+
+Note that the Maven build is provided for compatibility reasons, but
+it is considered to be deprecated and will be removed in a future
+version of this plugin.
+
+To build with Maven, run
+
+```
+mvn clean package
+```

--- a/src/main/resources/Documentation/cmd-add-user.md
+++ b/src/main/resources/Documentation/cmd-add-user.md
@@ -1,0 +1,37 @@
+@PLUGIN@ add-user
+=======================
+
+NAME
+----
+@PLUGIN@ add-user - Adds a user to the selfserv admin group and grants user
+                    'Create Project' capability in All-Projects.
+
+SYNOPSIS
+--------
+>    ssh -p <port> <host> @PLUGIN@ add-user NAME
+
+DESCRIPTION
+-----------
+Adds user to the selfserv admin group and grants user 'Create Project'
+capability in All-Projects.
+
+ACCESS
+------
+Any user in the 'Administrators' group and who has full admin capabilities.
+
+SCRIPTING
+---------
+This command is intended to be used in scripts.
+
+EXAMPLES
+--------
+
+Create a new project with default settings:
+
+>    $ ssh -p 29418 gerrit.host @PLUGIN@ add-user username
+
+SEE ALSO
+--------
+
+N/A
+

--- a/src/main/resources/Documentation/cmd-create-project.md
+++ b/src/main/resources/Documentation/cmd-create-project.md
@@ -1,0 +1,37 @@
+@PLUGIN@ create-project
+=======================
+
+NAME
+----
+@PLUGIN@ create-project - Create project in selfserv mode
+
+SYNOPSIS
+--------
+>    ssh -p <port> <host> @PLUGIN@ create-project NAME -- \
+>      --description DESC --parent PARENT --change-id --empty-commit
+
+DESCRIPTION
+-----------
+Creates new project with associated Git repository
+
+ACCESS
+------
+Any user who has been granted global 'Create Project' capabilities.
+
+SCRIPTING
+---------
+This command is intended to be used in scripts.
+
+EXAMPLES
+--------
+
+Create a new project with default settings:
+
+>    $ ssh -p 29418 gerrit.host @PLUGIN@ create-project my-project
+
+SEE ALSO
+--------
+
+* [@PLUGIN@ import-project command](cmd-import-project.md)
+
+

--- a/src/main/resources/Documentation/cmd-import-project.md
+++ b/src/main/resources/Documentation/cmd-import-project.md
@@ -1,0 +1,39 @@
+@PLUGIN@ import-project
+=======================
+
+NAME
+----
+@PLUGIN@ import-project - import project in selfserv mode
+
+SYNOPSIS
+--------
+>    ssh -p <port> <host> @PLUGIN@ import-project NAME -- \
+>      --description DESC --parent PARENT --source SOURCEURL \
+>      --change-id --empty-commit
+
+DESCRIPTION
+-----------
+Imports new project with associated Git repository from an existing Git remote.
+
+ACCESS
+------
+Any user who has been granted global 'Create Project' capabilities.
+
+SCRIPTING
+---------
+This command is intended to be used in scripts.
+
+EXAMPLES
+--------
+
+import a new project with default settings:
+
+>    $ ssh -p 29418 gerrit.host @PLUGIN@ import-project my-project \
+>      --source https://github.com/foo/bar.git
+
+SEE ALSO
+--------
+
+* [@PLUGIN@ create-project command](cmd-create-project.md)
+
+

--- a/src/main/resources/Documentation/config.md
+++ b/src/main/resources/Documentation/config.md
@@ -1,0 +1,13 @@
+@PLUGIN@ Configuration
+======================
+
+To configure @PLUGIN@ you can specify the group name which will be used
+to allow selfservice creation and importing of new Gerrit projects.
+
+The configuration must be done in the `gerrit.config` of the Gerrit server.
+
+```
+[selfserv]
+  adminGroup = "selfserv Admins"
+```
+

--- a/src/test/java/com/lookout/gerrit/selfserv/ssh/CreateProjectCommandTest.java
+++ b/src/test/java/com/lookout/gerrit/selfserv/ssh/CreateProjectCommandTest.java
@@ -1,0 +1,85 @@
+package com.lookout.gerrit.selfserv.ssh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.rules.ExpectedException;
+
+import com.google.gerrit.extensions.api.GerritApi;
+import com.google.gerrit.extensions.api.projects.Projects;
+import com.google.gerrit.extensions.restapi.RestApiException;
+
+import com.google.gerrit.reviewdb.client.AccountGroup;
+import com.google.gerrit.server.CurrentUser;
+import com.google.gerrit.server.account.AccountCache;
+import com.google.gerrit.server.account.GroupCache;
+import com.google.gerrit.server.account.GroupMembership;
+import com.google.gerrit.server.config.PluginConfigFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.PrintWriter;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ LoggerFactory.class, AccountGroup.class })
+public class CreateProjectCommandTest {
+
+  private GerritApi _gerritApi;
+  private CurrentUser _currentUser;
+  private GroupCache _groupCache;
+  private Logger _logger;
+  private PluginConfigFactory _pluginCfg;
+  private LoggerFactory _loggerFactory;
+  private PrintWriter _stdout;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setup() throws Exception {
+    _gerritApi = mock(GerritApi.class);
+    final Projects projects = mock(Projects.class);
+    when(projects.name(anyString())).thenReturn(null);
+    when(_gerritApi.projects()).thenReturn(projects);
+
+    _logger = mock(Logger.class);
+    _stdout = mock(PrintWriter.class);
+    mockStatic(LoggerFactory.class);
+    when(LoggerFactory.getLogger(any(Class.class))).thenReturn(_logger);
+
+    _pluginCfg = mock(PluginConfigFactory.class);
+
+    _currentUser = mock(CurrentUser.class);
+    final GroupMembership groups = mock(GroupMembership.class);
+    when(_currentUser.getEffectiveGroups()).thenReturn(groups);
+
+    _groupCache = mock(GroupCache.class);
+    final AccountGroup grp = mock(AccountGroup.class);
+    when(_groupCache.get(any(AccountGroup.NameKey.class))).thenReturn(grp);
+
+  }
+
+  // At the moment we are just testing no exception are thrown and that
+  // the #run() method completes each time.
+  @Test
+  public void testSshCommandWithSelfservAdminUser() throws Exception {
+    final CreateProjectCommand cmd = new CreateProjectCommand(
+      _gerritApi,
+      _pluginCfg,
+      _currentUser,
+      _groupCache,
+      _stdout);
+    cmd.run();
+  }
+}


### PR DESCRIPTION
For example, you can do this assuming your user is assigned create-project
capability in All-Projects:

```
$ ssh gerrit.server -- selfserv create-project NAME [--description DESC] ...
```

ADDITIONAL TODO for this PR:
- [x] Add `add-user` SSH command
- [ ] Add `import-project` SSH command
- [ ] Add better tests for `create-project` SSH command, such as:
  - [ ] sanity test arguments/options
  - [ ] happy path testing of of permissions
  - [ ] ensuring user without 'Create Project' capability AND in `adminGroup` cannot create project
- [ ] Add tests for `add-user` SSH command
- [ ] Add tests for `import-project` SSH command

DEFERRED TODO:
- [ ] Init step for installation UI wizard (for the point and click RelEng peeps)
- [ ] `add-user` UI action with corresponding tests
- [ ] `import-project` UI action with corresponding tests
- [ ] `add-user` REST API with corresponding tests
- [ ] `import-project` REST API with corresponding tests
